### PR TITLE
spec: clarify trailing data malleability in the `int` instruction

### DIFF
--- a/protocol/txvm/data.go
+++ b/protocol/txvm/data.go
@@ -107,7 +107,10 @@ func opInt(vm *VM) {
 	if n <= 0 {
 		panic(errors.WithData(ErrInt, "int", a))
 	}
-	// Note: if res > math.MaxInt64, this will convert it to a negative
+	// Note 1: as of TxVM version 3 we do not check whether `n` equals `len(a)`,
+	// which allows `a` to contain arbitrary trailing data.
+	// Relying on this behavior is discouraged as we may forbid it in the future version of TxVM.
+	// Note 2: if res > math.MaxInt64, this will convert it to a negative
 	// number. This is intentional!
 	vm.push(Int(res))
 }

--- a/specifications/txvm.md
+++ b/specifications/txvm.md
@@ -879,14 +879,20 @@ Note: Instructions `0x00` and `0x01` can be used to push
 _x_ **int** → _n_
 
 1. Pops a string `x` from the contract stack.
-2. Decodes it as a
+2. Decodes the prefix as a
    [LEB128](https://en.wikipedia.org/wiki/LEB128)-encoded unsigned
-   64-bit integer `u`.
+   64-bit integer `u`, ignoring any trailing bytes.
 3. Interprets the 64 bits of `u` as a signed two's complement 64-bit
    integer `n`.
 4. Pushes `n` to the contract stack.
 
 Fails execution when `x` is not a valid LEB128 encoding of an integer.
+
+Note: due to lack of clarity in the original specification and an accidental
+implementation, [transaction version 3](#versioning) allows integers to
+contain arbitrary trailing data after the valid LEB128 encoding.
+However, encoding integers with such trailing data is discouraged
+and may be forbidden in the future versions of TxVM.
 
 #### add
 


### PR DESCRIPTION
Turns out, the `int` instruction accidentally allows the string to contain arbitrary trailing data after the valid LEB128 encoding of an integer. We may want to forbid this in the future tx version, so lets add some clarifying notes and words of warning.